### PR TITLE
chore(backend): redis tls config

### DIFF
--- a/packages/backend/README.md
+++ b/packages/backend/README.md
@@ -21,3 +21,18 @@ In order to build the docker container run the following command.
 ```shell
 yarn docker build backend -t rafiki-backend
 ```
+
+## Configuration
+
+### Redis connection
+
+The connection can be configured by specifying the following environment variables.
+The config is passed to `ioredis` - see https://github.com/luin/ioredis#tls-options.
+| Variable | Default |
+|-----------------------------|------------------|
+| REDIS_HOST | "127.0.0.1" |
+| REDIS_PORT | 6379 |
+| REDIS_TLS_ENABLED | "false" |
+| REDIS_TLS_CA_FILE_PATH | "/certs/ca.crt" |
+| REDIS_TLS_KEY_FILE_PATH | "/certs/tls.key" |
+| REDIS_TLS_CERT_FILE_PATH | "/certs/tls.crt" |

--- a/packages/backend/src/config/app.ts
+++ b/packages/backend/src/config/app.ts
@@ -1,4 +1,5 @@
 import * as crypto from 'crypto'
+import { readFileSync } from 'fs'
 
 function envString(name: string, value: string): string {
   const envValue = process.env[name]
@@ -36,7 +37,23 @@ export const Config = {
           'postgresql://postgres:password@localhost:5432/development'
         ),
   env: envString('NODE_ENV', 'development'),
-  redisUrl: envString('REDIS_URL', 'redis://127.0.0.1:6379'),
+  redisHost: envString('REDIS_HOST', '127.0.0.1'),
+  redisPort: envInt('REDIS_PORT', 6379),
+  redisTls:
+    process.env.REDIS_TLS_ENABLED === 'true'
+      ? {
+          rejectUnauthorized: false, // allow self-signed certs
+          ca: readFileSync(
+            envString('REDIS_TLS_CA_FILE_PATH', '/certs/ca.crt')
+          ),
+          key: readFileSync(
+            envString('REDIS_TLS_KEY_FILE_PATH', '/certs/tls.key')
+          ),
+          cert: readFileSync(
+            envString('REDIS_TLS_CERT_FILE_PATH', '/certs/tls.crt')
+          )
+        }
+      : undefined,
   coilApiGrpcUrl: envString('COIL_API_GRPC_URL', 'localhost:6000'),
   nonceRedisKey: envString('NONCE_REDIS_KEY', 'nonceToProject'),
   adminKey: envString('ADMIN_KEY', 'qwertyuiop1234567890'),

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -99,7 +99,11 @@ export function initIocContainer(
   container.singleton('closeEmitter', async () => new EventEmitter())
   container.singleton('redis', async (deps) => {
     const config = await deps.use('config')
-    return new IORedis(config.redisUrl)
+    return new IORedis({
+      host: config.redisHost,
+      port: config.redisPort,
+      tls: config.redisTls
+    })
   })
   container.singleton('streamServer', async (deps) => {
     const config = await deps.use('config')


### PR DESCRIPTION
The ioredis client supports configuring tls certificates.
The redis host and port now needs to be specified using environment
variables as opposed to just the connection string.
https://github.com/luin/ioredis\#tls-options

<!--- Pull request titles should follow conventional commit format. -->

<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Changes proposed in this pull request
<!--
Provide a succinct description of what this pull request entails.
-->
- 

## Context
<!--
What were you trying to do?
Provide further details about how the feature should be tested/reviewed if necessary.
Link issues here -  using `fixes #number`
-->

## Checklist
<!--
Checklist items become clickable check boxes once the pull request is created. There is no need to edit them now.
-->

- [ ] Related issues linked using `fixes #number`
- [ ] Tests added/updated
- [ ] Documentation added
- [ ] Make sure that all checks pass
